### PR TITLE
fix behaviors of command, args parameter

### DIFF
--- a/python/packages/autogen-kubernetes-mcp/src/autogen_kubernetes_mcp/server.py
+++ b/python/packages/autogen-kubernetes-mcp/src/autogen_kubernetes_mcp/server.py
@@ -2,7 +2,7 @@ import argparse
 import asyncio
 import uuid
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, TypedDict
+from typing import Any, AsyncIterator, Optional, TypedDict
 
 from autogen_core import CancellationToken
 from mcp.server.fastmcp import Context, FastMCP
@@ -16,6 +16,11 @@ STATELESS_DESCRIPTION = r"""Use this tool to execute Python code in your chain o
 When you send a message containing python code to python, it will be executed in a stateless docker container, and the stdout of that process will be returned to you."""
 
 sessions: dict[str, list[Any]] = {}
+
+
+def split_str(val: str) -> Optional[list[str]]:
+    args = val.split()
+    return args if args else None
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -35,8 +40,18 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("-n", "--namespace", default="default")
     parser.add_argument("--volume", default=None)
     parser.add_argument("--pod-spec", default=None)
-    parser.add_argument("--command", nargs="+", help="jupyter server pod commands", default=None)
-    parser.add_argument("--args", nargs="+", help="jupyter server pod arguments", default=None)
+    parser.add_argument(
+        "--command",
+        type=split_str,
+        help="jupyter server pod commands (in single string)",
+        default=None,
+    )
+    parser.add_argument(
+        "--args",
+        type=split_str,
+        help="jupyter server pod arguments (in single string)",
+        default=None,
+    )
 
     return parser
 

--- a/python/packages/autogen-kubernetes-mcp/tests/test_executor.py
+++ b/python/packages/autogen-kubernetes-mcp/tests/test_executor.py
@@ -6,6 +6,7 @@ from autogen_kubernetes.code_executors import (
     PodCommandLineCodeExecutor,
     PodJupyterCodeExecutor,
 )
+from autogen_kubernetes.code_executors._jupyter_server import DEFAULT_COMMAND
 from autogen_kubernetes_mcp._executor import make_executor, run_code
 from conftest import kubernetes_enabled, state_kubernetes_enabled
 
@@ -33,7 +34,7 @@ async def test_vanilla_commandline_executor() -> None:
 @pytest.mark.skipif(not state_kubernetes_enabled or not can_resolve_svc_fqdn(), reason="kubernetes not accessible")
 @pytest.mark.asyncio
 async def test_vanilla_jupyter_executor() -> None:
-    instances = await make_executor({"type": "jupyter"})
+    instances = await make_executor({"type": "jupyter", "command": DEFAULT_COMMAND})
     executor = instances[0]
     assert isinstance(executor, PodJupyterCodeExecutor)
     result = await run_code(executor, 'print("Hello")', CancellationToken())

--- a/python/packages/autogen-kubernetes/src/autogen_kubernetes/code_executors/_jupyter_server.py
+++ b/python/packages/autogen-kubernetes/src/autogen_kubernetes/code_executors/_jupyter_server.py
@@ -197,7 +197,7 @@ class PodJupyterServer(Component[PodJupyterServerConfig], ComponentBase[BaseMode
         *,
         image: Optional[str] = None,
         pod_name: Optional[str] = None,
-        command: Optional[list[str]] = None,
+        command: Optional[list[str]] = DEFAULT_COMMAND,
         args: Optional[list[str]] = None,
         timeout: int = 60,
         workspace_path: Union[Path, str] = "/workspace",
@@ -304,7 +304,7 @@ class PodJupyterServer(Component[PodJupyterServerConfig], ComponentBase[BaseMode
         self._namespace = namespace
         self._timeout = timeout
         self._auto_remove = auto_remove
-        self._command = command or DEFAULT_COMMAND
+        self._command = command
         self._args = args
         ## workspace
         if isinstance(workspace_path, str):  ## path string to Path
@@ -553,6 +553,7 @@ class PodJupyterServer(Component[PodJupyterServerConfig], ComponentBase[BaseMode
             image=config.image,
             pod_name=config.pod_name,
             command=config.command,
+            args=config.args,
             timeout=config.timeout,
             workspace_path=config.workspace_path,
             namespace=config.namespace,


### PR DESCRIPTION
jupyter
- DEFAULT_COMMAND is used when command argument parameter is not provided. 
- None value provided in command parameter is applied as literally None command in pod container.
- fix: add args in initialize at _from_config

mcp
- command, args argument uses single string